### PR TITLE
testing: allow e2e tests to clear the database before running

### DIFF
--- a/cypress/integration/api.test.ts
+++ b/cypress/integration/api.test.ts
@@ -3,6 +3,7 @@ import { List, ListItem } from '../../src/modules/lists/types'
 describe('API', () => {
   beforeEach(() => {
     cy.server()
+    cy.task('clearDatabase')
   })
 
   context('GET /api/lists', () => {

--- a/cypress/integration/e2e.test.ts
+++ b/cypress/integration/e2e.test.ts
@@ -3,6 +3,7 @@ import { List } from '../../src/modules/lists/types'
 describe('E2E', () => {
   beforeEach(() => {
     cy.server()
+    cy.task('clearDatabase')
     cy.viewport('iphone-x')
   })
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -15,11 +15,35 @@
 /**
  * @type {Cypress.PluginConfig}
  */
+require('dotenv').config()
+const faunadb = require('faunadb')
 const dotenvPlugin = require('cypress-dotenv')
+
+const secret = process.env.FAUNADB_KEY
+
+const q = faunadb.query
+const client = new faunadb.Client({ secret })
 
 // `on` is used to hook into various events Cypress emits
 // `config` is the resolved Cypress config
 module.exports = (on, config) => {
+  on('task', {
+    async clearDatabase() {
+      await client.query(
+        q.Do(
+          q.Map(q.Paginate(q.Match(q.Index('all_lists'))), (ref) =>
+            q.Delete(ref)
+          ),
+          q.Map(q.Paginate(q.Match(q.Index('all_items'))), (ref) =>
+            q.Delete(ref)
+          )
+        )
+      )
+
+      return true
+    },
+  })
+
   config = dotenvPlugin(config)
   return config
 }

--- a/migrations/1590885603861-add-all-items-index.ts
+++ b/migrations/1590885603861-add-all-items-index.ts
@@ -1,0 +1,32 @@
+import * as faunadb from 'faunadb'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const secret = process.env.FAUNADB_KEY as string
+
+const client = new faunadb.Client({ secret })
+const q = faunadb.query
+
+exports.up = async () => {
+  try {
+    await client.query(
+      q.CreateIndex({
+        name: 'all_items',
+        source: q.Collection('items'),
+      })
+    )
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
+exports.down = async () => {
+  try {
+    await client.query(q.Delete(q.Index('all_items')))
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "e2e:open": "yarn cypress open",
     "migrate:make": "yarn migrate --compiler=\"ts:./migrate-compiler.js\" --store=\"./migrate-store.ts\" create",
     "migrate:up": "yarn migrate --compiler=\"ts:./migrate-compiler.js\" --store=\"./migrate-store.ts\" up",
-    "migrate:down": "yarn migrate --compiler=\"ts:./migrate-compiler.js\" --store=\"./migrate-store.ts\" down"
+    "migrate:down": "yarn migrate --compiler=\"ts:./migrate-compiler.js\" --store=\"./migrate-store.ts\" down",
+    "migrate:list": "yarn migrate --compiler=\"ts:./migrate-compiler.js\" --store=\"./migrate-store.ts\" list"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",


### PR DESCRIPTION
### Description 

This allows the end-to-end tests to have more predictable test results since the database is cleared out between every test.

This also means that the end-to-end tests should _never_ be run against the production database, as this would potentially remove production data.

### Next Steps

As a next step, it might make sense to introduce some flags on the end-to-end tests to allow flagging certain tests as "run in production" and others as "only run in non-production environments". This would allow maintaining a set of generic smoketests as well as a more complete set of tests that setup/teardown test data